### PR TITLE
fix config pull chain

### DIFF
--- a/src/pbfetch/main_funcs/fetch.py
+++ b/src/pbfetch/main_funcs/fetch.py
@@ -1,12 +1,30 @@
-import re, os
+import re, os, shutil
 from subprocess import Popen, PIPE
 
 import pbfetch.main_funcs.horizontal_formatter as hf
 from pbfetch.main_funcs.stats import stats
 
-# init stats using keywords for configuration in .conf
-file = os.path.join("src", "pbfetch", "config", "config.txt")
+# from pbfetch.main_funcs.stats import system
+
 stats_dict = stats()
+system = stats_dict["$SYSTEM"]
+user = stats_dict["$USER"]
+
+if system != "Linux":
+    print("This fetch is currently only supported on linux, sorry!")
+    exit()
+
+
+"""/usr/share/pbfetch/config/"""
+
+
+file = "config.txt"
+usr_share = os.path.join("/", "usr", "share", "pbfetch", "config")
+config_directory = os.path.join("/", "home", user, ".config", "pbfetch", "config")
+
+
+# # init stats using keywords for configuration in .conf
+# file = os.path.join("src", "pbfetch", "config", "config.txt")
 
 
 def get_console_width():
@@ -17,14 +35,40 @@ def get_console_width():
 
 
 def fetch():
-    # read config and exit if empty
-    with open(file, "r") as config:
-        content = config.read()
-        if content:
-            fetch_data = content
-        else:
-            print("You must insert something in the config! Try some ascii art UwU")
-            exit()
+    # copy a default config into ~/.config/pbfetch/config/ on first launch
+    if os.path.isdir(config_directory):
+        if os.path.exists(os.path.join(config_directory, file)) is not True:
+            print("Generating default config")
+            shutil.copy(
+                os.path.join(usr_share, file),
+                os.path.join(config_directory, file),
+            )
+        with open(os.path.join(config_directory, file)) as fetch_data:
+            content = fetch_data.read()
+
+            if content:
+                fetch_data = content
+            else:
+                print("The config is empty! Try adding some ascii art OwO")
+                print(f"The config can be located in {config_directory}")
+                exit()
+
+    else:
+        print(f"Generating new config in {config_directory}")
+        with open(str(os.path.join(usr_share, file))) as usr_share_file:
+            content = usr_share_file.read()
+
+            if content:
+                os.makedirs(config_directory)
+                shutil.copy(
+                    os.path.join(usr_share, file),
+                    os.path.join(config_directory, file),
+                )
+                fetch_data = content
+                print("Default config copied successfully")
+            else:
+                print("The default config is empty...Uh Oh!")
+                exit()
 
     # omit comments from output
     for line in fetch_data.split("\n"):

--- a/src/pbfetch/main_funcs/stats.py
+++ b/src/pbfetch/main_funcs/stats.py
@@ -5,7 +5,7 @@ import pbfetch.parse_funcs.parse_cpu as cpu
 import pbfetch.parse_funcs.parse_mem as mem
 import pbfetch.parse_funcs.parse_login as login
 import pbfetch.parse_funcs.parse_kernel as kernel
-import pbfetch.parse_funcs.parse_hostname as hostname
+# import pbfetch.parse_funcs.parse_hostname as hostname
 # import pbfetch.parse_funcs.parse_cpu_usage as cpu_usage
 
 import subprocess, platform, psutil
@@ -68,8 +68,10 @@ def stats():
 
     # TODO: add easter egg stats for fun dynamic things
     # init stats using keywords for configuration in .conf
-    stats = {
+    stats_dict = {
+        "$SYSTEM": system,
         # "$UNAME": _uname,
+        "$USER": stat_user,
         "$HOST": stat_hostname,
         "$SYS": stat_os,
         # "$ARCH": stat_arch,
@@ -92,4 +94,4 @@ def stats():
 
 
 
-    return stats
+    return stats_dict


### PR DESCRIPTION
if ~/.config/pbfetch/config/config.txt doesnt exist, the program will pull the default data from /usr/share/pbfetch/config/config.txt

the /usr/share config should be generated when the package is created