### PR TITLE
include pkgbuild

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Your Name <penny belle 98 at gmail dot com>
+pkgname=pbfetch-git
+pkgver=r124.dc4b440
+pkgrel=1
+pkgdesc="An unbelievably customizable hardware/software fetch"
+arch=('x86_64' 'aarch64')
+url="https://github.com/pennybelle/pbfetch"
+license=('Apache-2.0')
+depends=("python-psutil")
+makedepends=(python-build python-installer python-wheel python-hatchling git)
+provides=("${pkgname}")
+conflicts=("${pkgname}")
+source=("git+https://github.com/pennybelle/pbfetch.git")
+sha256sums=('SKIP')
+# dist=("${pkgname}")
+# groups=()omg
+
+pkgver() {
+    cd "$srcdir/${pkgname%-git}"
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+    cd "$srcdir/${pkgname%-git}"
+    python -m build --wheel --no-isolation
+    # rye publish
+    # build --wheel --no-isolation
+}
+
+package() {
+    cd "$srcdir/${pkgname%-git}"
+    echo "Copying config to /usr/share/pbfetch/config/"
+    sudo cp "$srcdir/${pkgname%-git}/src/${pkgname%-git}/config/config.txt" "/usr/share/pbfetch/config/config.txt"
+    python -m installer --destdir="$pkgdir" dist/*.whl
+    install -Dm0755 pbfetch "$pkgdir/usr/bin/pbfetch"
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Your Name <penny belle 98 at gmail dot com>
+# Maintainer: Penelope Belle <penny belle 98 at gmail dot com>
 pkgname=pbfetch-git
 pkgver=r124.dc4b440
 pkgrel=1
@@ -12,8 +12,6 @@ provides=("${pkgname}")
 conflicts=("${pkgname}")
 source=("git+https://github.com/pennybelle/pbfetch.git")
 sha256sums=('SKIP')
-# dist=("${pkgname}")
-# groups=()omg
 
 pkgver() {
     cd "$srcdir/${pkgname%-git}"
@@ -22,15 +20,16 @@ pkgver() {
 
 build() {
     cd "$srcdir/${pkgname%-git}"
+    echo "Building binary ..."
     python -m build --wheel --no-isolation
-    # rye publish
-    # build --wheel --no-isolation
 }
 
 package() {
     cd "$srcdir/${pkgname%-git}"
-    echo "Copying config to /usr/share/pbfetch/config/"
+    echo "Copying default config to /usr/share/pbfetch/config/ (requires pass) ..."
     sudo cp "$srcdir/${pkgname%-git}/src/${pkgname%-git}/config/config.txt" "/usr/share/pbfetch/config/config.txt"
+    echo "Installing binary ..."
     python -m installer --destdir="$pkgdir" dist/*.whl
     install -Dm0755 pbfetch "$pkgdir/usr/bin/pbfetch"
+    echo "Installed successfully! Please restart your shell to use pbfetch. Enjoy! OwO"
 }


### PR DESCRIPTION
to make pbfetch into a binary, do `makepkg -si` in the cloned directory. make sure to restart your shell after installing the fetch c: