### PR TITLE
Small fix with environment variable parsing

### DIFF
--- a/src/pbfetch/main_funcs/stats.py
+++ b/src/pbfetch/main_funcs/stats.py
@@ -101,7 +101,7 @@ def stats():
         )
     
     def stat_shell():
-        shell_pre_parse = "bash" #environ["SHELL"].replace("/bin/", "")
+        shell_pre_parse = environ["SHELL"].replace("/usr/bin/", "")
         shell_mid_parse = str(
             subprocess.check_output(
                 [f"{shell_pre_parse}", "--version"]

--- a/src/pbfetch/main_funcs/stats.py
+++ b/src/pbfetch/main_funcs/stats.py
@@ -101,7 +101,7 @@ def stats():
         )
     
     def stat_shell():
-        shell_pre_parse = environ["SHELL"].replace("/bin/", "")
+        shell_pre_parse = "bash" #environ["SHELL"].replace("/bin/", "")
         shell_mid_parse = str(
             subprocess.check_output(
                 [f"{shell_pre_parse}", "--version"]


### PR DESCRIPTION
In the `stat_shell()` function (located in `src/pbfetch/main_funcs/stats.py`), `shell_pre_parse` is incorrect. `environ["SHELL"]` is equal to `/usr/bin/shell-name-here`, and thus the replace function (`replace("/bin/", "")`) is incorrect. It should be equal to `replace("/usr/bin/", "")` instead.

All that being said, I might be wrong, and it might be an issue with my system. 

Also, sorry for the small PR. I don't normally do this and I want to make sure I'm doing it right lol. 