### PR TITLE
Add code formatting and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: ci
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Lint and format code
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install the latest version of rye
+        uses: eifinger/setup-rye@v4
+
+      - name: Instal dependencies
+        run: rye sync --no-lock
+
+      - name: Lint code
+        run: rye check
+
+      - name: Check formatting
+        run: rye fmt --check

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ config/
 
 # backup
 backup/
+
+.ruff_cache

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+exclude = [".git", ".venv", "gallery", "src/pbfetch/BACKUP"]

--- a/src/pbfetch/main_funcs/horizontal_formatter.py
+++ b/src/pbfetch/main_funcs/horizontal_formatter.py
@@ -62,7 +62,9 @@ def replace_keyword(template, keyword, replace_text):
         # Pad replaceText with spaces to match the whitespace we removed
         # insert color reset bytecode at the beginning of each line
         # to prevent buggy behavior
-        replaced_template.append("</rgb>" + split_line[0] + replace_text + split_line[1])
+        replaced_template.append(
+            "</rgb>" + split_line[0] + replace_text + split_line[1]
+        )
 
     template = "\n".join(replaced_template)
 

--- a/src/pbfetch/main_funcs/stats.py
+++ b/src/pbfetch/main_funcs/stats.py
@@ -2,7 +2,6 @@ from os import environ, path
 from subprocess import check_output
 from platform import uname, machine
 from pathlib import Path
-from psutil import cpu_percent
 
 
 def get_config_dir():

--- a/src/pbfetch/parse_funcs/parse_res.py
+++ b/src/pbfetch/parse_funcs/parse_res.py
@@ -1,5 +1,4 @@
 import os
-from subprocess import run
 
 
 def parse_res():
@@ -23,7 +22,7 @@ def parse_res():
     #         if os.path.exists(edid_path) is not True:
     #             print("no path")
     #             continue
-            
+
     #         with open(edid_path, mode="rb") as edid:
     #             byte = edid.read()
     #             while byte != b"":
@@ -34,9 +33,8 @@ def parse_res():
     #             continue
     #     print(edid)
     #     return
-    
+
     # except AttributeError:
-        
 
     # except Exception as e:
     #     print(e)


### PR DESCRIPTION
This pull request introduces linting and formatting configuration using [Ruff](https://astral.sh/ruff). Since Ruff is already integrated with Rye, no additional dependencies are required. Additionally, I've implemented a GitHub Action to automatically check linting and formatting for each push and pull request.