### PR TITLE
Fix `SyntaxError`

### DIFF
--- a/src/pbfetch/main_funcs/stats.py
+++ b/src/pbfetch/main_funcs/stats.py
@@ -31,7 +31,7 @@ def stat_architecture():
 
 def stat_hostname():
     # return f"{login.parse_login()}@{hostname.parse_hostname()}"
-    return f"{environ["USER"]}@{stat_host()}"
+    return f"{environ['USER']}@{stat_host()}"
 
 
 def stat_datetime():


### PR DESCRIPTION
> Prior to Python 3.12, reuse of the same quoting type of the outer f-string inside a replacement field was not possible. (https://docs.python.org/3/reference/lexical_analysis.html#formatted-string-literals)

This change allows the script to run in earlier versions of Python.