### PR TITLE
More accurate nvidia gpu name using nvidia-smi

### DIFF
--- a/src/pbfetch/parse/gpu.py
+++ b/src/pbfetch/parse/gpu.py
@@ -1,7 +1,6 @@
 from pbfetch.handle_error import error
 from subprocess import Popen, PIPE
 from re import sub
-# import nvidia_smi
 
 
 def command(input):
@@ -18,13 +17,13 @@ def command(input):
 
 
 def parse_gpu():
-    # try:
-    #     nvidia_smi.nvmlInit()
-    #     handle = nvidia_smi.nvmDeviceGetHandleByIndex(0)
-    #     print(handle)
+    try:
+        gpu_name = command("nvidia-smi --query-gpu=name --format=csv,noheader")
 
-    # except Exception:
-    #     pass
+        return gpu_name.strip()
+
+    except Exception:
+        pass
 
     try:
         gpu_name = command("lspci | grep -i nvidia")


### PR DESCRIPTION
Tries using nvidia-smi to get the gpu name. On my machine this gives a much nicer output:

![image](https://github.com/user-attachments/assets/7657a79b-0953-49d2-8f98-20187c0656d3)
*current output*

![image](https://github.com/user-attachments/assets/3fcaca04-c95c-44f0-b7a6-32bceedb05fa)
*using nvidia-smi*